### PR TITLE
fix: extend EventuallyWithT deadlines past subscriber poll interval

### DIFF
--- a/pkg/bolt/delay_test.go
+++ b/pkg/bolt/delay_test.go
@@ -49,7 +49,7 @@ func TestDelayedBoltPublisherNoDelay(t *testing.T) {
 		default:
 			t.Errorf("message should be received")
 		}
-	}, time.Second, time.Millisecond*10)
+	}, time.Second*3, time.Millisecond*10)
 }
 
 func TestDelayedBoltPublisherWithDelay(t *testing.T) {
@@ -90,7 +90,7 @@ func TestDelayedBoltPublisherWithDelay(t *testing.T) {
 		default:
 			t.Errorf("message should be received")
 		}
-	}, time.Second*5, time.Millisecond*10)
+	}, time.Second*7, time.Millisecond*10)
 
 	select {
 	case <-messages:


### PR DESCRIPTION
```
The delay tests' EventuallyWithT deadlines were set equal to (or only barely longer than) the subscriber's hardcoded 1s bucket-poll interval, producing a guaranteed near-miss:

  TestDelayedBoltPublisherNoDelay
    t=0ms     Subscribe starts goroutine, poll #1 runs immediately,
              bucket is empty (Publish has not run yet), subscriber
              sleeps 1s
    t=~10ms   test calls Publish, msg lands in bucket
    t=10-1000 EventuallyWithT ticks the channel every 10ms but the
              subscriber is still sleeping, nothing delivered
    t=1000ms  EventuallyWithT deadline expires, test fails
    t=1001ms  subscriber wakes, poll #2 finds the msg (too late)

  TestDelayedBoltPublisherWithDelay second window
    Same shape, just shifted 4s: deadline 5s, real wait ~5s + up to 1s
    of poll lag = same near-miss against a 5s budget.

Bump deadlines to 3s and 7s respectively so poll #2 always lands well before the assertion gives up.
```